### PR TITLE
vim-patch:bee966d,6fea0a5,5ddcecf,0b540c6,0b540c6

### DIFF
--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -391,4 +391,10 @@ highlighting.  So do these:
 You can find the details in $VIMRUNTIME/syntax/help.vim
 
 
+FILETYPE COMPLETION					*ft-help-omni*
+
+To get completion for help tags when writing a tag reference, you can use the
+|i_CTRL-X_CTRL-O| command.
+
+
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -118,6 +118,7 @@ DIAGNOSTICS
 EDITOR
 
 • |:iput| works like |:put| but adjusts indent.
+• |omnicompletion| in `help` buffer. |ft-help-omni|
 
 EVENTS
 

--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:             Vim help file
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2018-12-29
+" Last Change:          2025 Apr 08
+" 2025 Apr 08 by Vim project (set 'omnifunc' and 'iskeyword', #17073)
 
 if exists("b:did_ftplugin")
   finish
@@ -11,15 +12,33 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-let b:undo_ftplugin = "setl fo< tw< cole< cocu< keywordprg<"
+let b:undo_ftplugin = "setl isk< fo< tw< cole< cocu< keywordprg< omnifunc<"
 
-setlocal formatoptions+=tcroql textwidth=78
+setlocal formatoptions+=tcroql textwidth=78 keywordprg=:help omnifunc=s:HelpComplete
+let &l:iskeyword='!-~,^*,^|,^",192-255'
 if has("conceal")
   setlocal cole=2 cocu=nc
 endif
 
-" Prefer Vim help instead of manpages.
-setlocal keywordprg=:help
+if !exists('*s:HelpComplete')
+  func s:HelpComplete(findstart, base)
+    if a:findstart
+      let colnr = col('.') - 1 " Get the column number before the cursor
+      let line = getline('.')
+      for i in range(colnr - 1, 0, -1)
+        if line[i] ==# '|'
+          return i + 1 " Don't include the `|` in base
+        elseif line[i] ==# "'"
+          return i " Include the `'` in base
+        endif
+      endfor
+    else
+      return taglist('^' .. a:base)
+            \ ->map({_, item -> #{word: item->get('name'), kind: item->get('kind')}})
+            \ ->extend(getcompletion(a:base, 'help'))
+    endif
+  endfunc
+endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
#### vim-patch:bee966d: runtime(doc): clarify `:help inclusion` section

https://github.com/vim/vim/commit/bee966d3fe96f20656183d260dd03f6abb11ad79

Co-authored-by: Ernie Rael <errael@raelity.com>


#### vim-patch:6fea0a5: runtime(help): Add Vim lang annotation support for codeblocks

closes: vim/vim#16215

https://github.com/vim/vim/commit/6fea0a54804fc36ab7138a66210b0eb380d96198

Co-authored-by: Shougo Matsushita <Shougo.Matsu@gmail.com>
Co-authored-by: zeertzjq <zeertzjq@outlook.com>


#### vim-patch:5ddcecf: runtime(help): Add better support for language annotation highlighting

closes: vim/vim#16238

https://github.com/vim/vim/commit/5ddcecf05febcdd374f47bea856830c3b6d1bff8

Co-authored-by: Shougo Matsushita <Shougo.Matsu@gmail.com>
Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: h_east <h.east.727@gmail.com>


#### vim-patch:0b540c6: runtime(help): add omni completion and 'iskeyword' to filetype plugin

Problem:

- Help tags provide a good way to navigate the Vim documentation, but
  many help documents don't use them effectively. I think one of the
  reasons is that help writers have to look up help tags manually with
  `:help` command, which is not very convenient.
- 'iskeyword' is only set for help buffers opened by `:help` command.
  That means if I'm editing a help file, I cannot jump to tag in same
  file using `Ctrl-]` unless I manually set it, which is annoying.

Solution:

- Add omni completion for Vim help tags.
- Set 'iskeyword' for `ft-help`

closes: vim/vim#17073

https://github.com/vim/vim/commit/0b540c6f381c63c2d80cc0aaef76b0df008b9f86

Co-authored-by: Phạm Bình An <phambinhanctb2004@gmail.com>
Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:0b540c6: runtime(help): add omni completion and 'iskeyword' to filetype plugin

Problem:

- Help tags provide a good way to navigate the Vim documentation, but
  many help documents don't use them effectively. I think one of the
  reasons is that help writers have to look up help tags manually with
  `:help` command, which is not very convenient.
- 'iskeyword' is only set for help buffers opened by `:help` command.
  That means if I'm editing a help file, I cannot jump to tag in same
  file using `Ctrl-]` unless I manually set it, which is annoying.

Solution:

- Add omni completion for Vim help tags.
- Set 'iskeyword' for `ft-help`

closes: vim/vim#17073

https://github.com/vim/vim/commit/0b540c6f381c63c2d80cc0aaef76b0df008b9f86

Co-authored-by: Phạm Bình An <phambinhanctb2004@gmail.com>
Co-authored-by: Christian Brabandt <cb@256bit.org>